### PR TITLE
security: secret_keyのハードコーディング問題を修正 #30

### DIFF
--- a/lambapi/auth/base_user.py
+++ b/lambapi/auth/base_user.py
@@ -22,7 +22,6 @@ class Meta:
     """BaseUser のデフォルトメタ設定"""
 
     table_name = "users"
-    secret_key = "your_secret_key"
     expiration = 3600
     id_type = "uuid"
     is_email_login = False
@@ -157,11 +156,6 @@ class BaseUser:
     def _get_table_name(cls) -> str:
         """テーブル名を取得"""
         return cls.Meta.table_name
-
-    @classmethod
-    def _get_secret_key(cls) -> str:
-        """秘密鍵を取得"""
-        return cls.Meta.secret_key
 
     @classmethod
     def _get_expiration(cls) -> int:


### PR DESCRIPTION
## 概要

Issue #30 の secret_key ハードコーディング問題を修正しました。セキュリティリスクを解消し、ユーザーフレンドリーな設定方法を提供します。

## 主な変更内容

### セキュリティ改善
- ✅ **Meta クラスから固定 secret_key を削除**: ソースコードに機密情報を含まない
- ✅ **必須設定化**: secret_key 設定なしではエラーになり、適切な設定を促進
- ✅ **分かりやすいエラーメッセージ**: 設定方法を具体的に案内

### 使いやすさ向上  
- ✅ **2つの設定方法をサポート**:
  1. 明示的指定: `DynamoDBAuth(secret_key="key")`
  2. 環境変数: `export LAMBAPI_SECRET_KEY="key"`
- ✅ **明確な優先順位**: 明示的指定 → 環境変数 → エラー

### 後方互換性
- ✅ **既存コードは環境変数設定のみで動作継続**
- ✅ **API 仕様は維持**: 新しい secret_key パラメータを追加

## 技術詳細

### 変更されたファイル
- `lambapi/auth/base_user.py`: Meta.secret_key 削除、_get_secret_key メソッド削除  
- `lambapi/auth/dynamodb_auth.py`: 初期化ロジックで優先順位実装
- `tests/test_auth.py`: 新仕様テスト追加
- `docs/guides/authentication.md`: セキュリティベストプラクティス追加

### 新しい使用方法

**推奨方法（環境変数）:**
```bash
export LAMBAPI_SECRET_KEY="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
```
```python
auth = DynamoDBAuth()  # 環境変数から自動取得
```

**明示的指定（開発・テスト用）:**
```python
auth = DynamoDBAuth(secret_key="development-key")
```

## テスト

- ✅ BaseUser テスト: 5/5 パス
- ✅ DynamoDBAuth テスト: secret_key 必須化テスト追加
- ✅ 環境変数テスト: 優先順位の動作確認  
- ✅ 品質チェック: Black, Flake8, MyPy, Bandit 全て通過

## 影響とリスク

### 正の影響
- セキュリティリスクの完全解消
- セキュリティ意識の向上促進
- 明確な設定ガイダンス

### 潜在的リスク
- 既存ユーザーは環境変数設定が必要（1行の設定で解決）
- エラーメッセージで適切に案内済み

Closes #30