### PR TITLE
refactor: 未使用のrequest_format/response_formatパラメータをAPIから完全削除

### DIFF
--- a/lambapi/base_router.py
+++ b/lambapi/base_router.py
@@ -4,7 +4,7 @@ Base Router クラス
 HTTP メソッドデコレータの共通実装を提供します。
 """
 
-from typing import Callable, Optional, Type, Union, Any
+from typing import Callable, Union, Any
 from .cors import CORSConfig
 
 
@@ -16,8 +16,6 @@ class BaseRouterMixin:
         path: str,
         method: str,
         handler: Callable[..., Any],
-        request_format: Optional[Type[Any]] = None,
-        response_format: Optional[Type[Any]] = None,
         cors: Union[bool, CORSConfig, None] = None,
     ) -> Any:
         """サブクラスで実装する必要があるメソッド"""
@@ -26,69 +24,59 @@ class BaseRouterMixin:
     def get(
         self,
         path: str = "/",
-        request_format: Optional[Type[Any]] = None,
-        response_format: Optional[Type[Any]] = None,
         cors: Union[bool, CORSConfig, None] = None,
     ) -> Callable[[Callable[..., Any]], Any]:
         """GET エンドポイントのデコレータ"""
 
         def decorator(handler: Callable[..., Any]) -> Any:
-            return self._add_route(path, "GET", handler, request_format, response_format, cors)
+            return self._add_route(path, "GET", handler, cors)
 
         return decorator
 
     def post(
         self,
         path: str = "/",
-        request_format: Optional[Type[Any]] = None,
-        response_format: Optional[Type[Any]] = None,
         cors: Union[bool, CORSConfig, None] = None,
     ) -> Callable[[Callable[..., Any]], Any]:
         """POST エンドポイントのデコレータ"""
 
         def decorator(handler: Callable[..., Any]) -> Any:
-            return self._add_route(path, "POST", handler, request_format, response_format, cors)
+            return self._add_route(path, "POST", handler, cors)
 
         return decorator
 
     def put(
         self,
         path: str = "/",
-        request_format: Optional[Type[Any]] = None,
-        response_format: Optional[Type[Any]] = None,
         cors: Union[bool, CORSConfig, None] = None,
     ) -> Callable[[Callable[..., Any]], Any]:
         """PUT エンドポイントのデコレータ"""
 
         def decorator(handler: Callable[..., Any]) -> Any:
-            return self._add_route(path, "PUT", handler, request_format, response_format, cors)
+            return self._add_route(path, "PUT", handler, cors)
 
         return decorator
 
     def delete(
         self,
         path: str = "/",
-        request_format: Optional[Type[Any]] = None,
-        response_format: Optional[Type[Any]] = None,
         cors: Union[bool, CORSConfig, None] = None,
     ) -> Callable[[Callable[..., Any]], Any]:
         """DELETE エンドポイントのデコレータ"""
 
         def decorator(handler: Callable[..., Any]) -> Any:
-            return self._add_route(path, "DELETE", handler, request_format, response_format, cors)
+            return self._add_route(path, "DELETE", handler, cors)
 
         return decorator
 
     def patch(
         self,
         path: str = "/",
-        request_format: Optional[Type[Any]] = None,
-        response_format: Optional[Type[Any]] = None,
         cors: Union[bool, CORSConfig, None] = None,
     ) -> Callable[[Callable[..., Any]], Any]:
         """PATCH エンドポイントのデコレータ"""
 
         def decorator(handler: Callable[..., Any]) -> Any:
-            return self._add_route(path, "PATCH", handler, request_format, response_format, cors)
+            return self._add_route(path, "PATCH", handler, cors)
 
         return decorator

--- a/lambapi/core.py
+++ b/lambapi/core.py
@@ -10,7 +10,6 @@ from typing import Dict, Any, Callable, Optional, List, Type, Union
 
 from .request import Request
 from .response import Response
-from .validation import validate_and_convert, convert_to_dict
 from .cors import CORSConfig, create_cors_config
 from .error_handlers import get_global_registry
 from .base_router import BaseRouterMixin
@@ -77,15 +76,11 @@ class Route:
         path: str,
         method: str,
         handler: Callable,
-        request_format: Optional[Type] = None,
-        response_format: Optional[Type] = None,
         cors_config: Optional[CORSConfig] = None,
     ):
         self.path = path
         self.method = method.upper()
         self.handler = handler
-        self.request_format = request_format
-        self.response_format = response_format
         self.cors_config = cors_config
         self.path_regex = self._compile_path_regex(path)
 
@@ -241,8 +236,6 @@ class API(BaseRouterMixin):
                         new_path,
                         route.method,
                         route.handler,
-                        route.request_format,
-                        route.response_format,
                     )
                     new_router.routes.append(new_route)
                 self.routes.extend(new_router.routes)
@@ -269,8 +262,6 @@ class API(BaseRouterMixin):
         path: str,
         method: str,
         handler: Callable,
-        request_format: Optional[Type] = None,
-        response_format: Optional[Type] = None,
         cors: Union[bool, CORSConfig, None] = None,
     ) -> Callable:
         """ルートを追加"""
@@ -281,7 +272,7 @@ class API(BaseRouterMixin):
         elif isinstance(cors, CORSConfig):
             cors_config = cors
 
-        route = Route(path, method, handler, request_format, response_format, cors_config)
+        route = Route(path, method, handler, cors_config)
         self.routes.append(route)
         self._update_route_index(route)
         return handler
@@ -319,23 +310,11 @@ class API(BaseRouterMixin):
         signature = _SIGNATURE_CACHE[handler]
         handler_params = signature.parameters
 
-        # リクエストフォーマットが指定されている場合、リクエストをバリデーション
-        validated_request_data = None
-        if route.request_format:
-            try:
-                request_data = request.json()
-                validated_request_data = validate_and_convert(request_data, route.request_format)
-            except Exception as e:
-                raise ValueError(f"リクエストバリデーションエラー: {str(e)}")
-
-        # 最初の引数が request またはバリデーション済みリクエストかどうかをチェック
+        # 最初の引数が request かどうかをチェック
         param_names = list(handler_params.keys())
         if param_names and param_names[0] in ["request", "req"]:
             # 従来の方式（request を第一引数に渡す）
-            if route.request_format and validated_request_data:
-                return handler(validated_request_data)
-            else:
-                return handler(request)
+            return handler(request)
 
         call_args: Dict[str, Any] = {}
 
@@ -362,10 +341,7 @@ class API(BaseRouterMixin):
 
         # request 引数がある場合は追加
         if "request" in handler_params:
-            if route.request_format and validated_request_data:
-                call_args["request"] = validated_request_data
-            else:
-                call_args["request"] = request
+            call_args["request"] = request
 
         # キーワード引数として渡す、もしくは引数なしで呼び出し
         return handler(**call_args) if call_args else handler()
@@ -416,7 +392,6 @@ class API(BaseRouterMixin):
     def _process_response(self, result: Any, route: Route, request: Request) -> Response:
         """レスポンスを処理"""
         # レスポンスフォーマットバリデーション
-        result = self._validate_response_format(result, route, request)
         if isinstance(result, dict) and "statusCode" in result:
             return Response(result)  # エラーレスポンス
 
@@ -441,31 +416,6 @@ class API(BaseRouterMixin):
         response = self._apply_cors_headers(request, response, route)
 
         return response
-
-    def _validate_response_format(self, result: Any, route: Route, request: Request) -> Any:
-        """レスポンスフォーマットをバリデーション"""
-        if route.response_format and result is not None:
-            try:
-                if isinstance(result, dict):
-                    validated_result = validate_and_convert(result, route.response_format)
-                    return convert_to_dict(validated_result)
-                elif hasattr(result, "__dict__"):
-                    result_dict = result.__dict__ if hasattr(result, "__dict__") else {}
-                    validated_result = validate_and_convert(result_dict, route.response_format)
-                    return convert_to_dict(validated_result)
-            except Exception as e:
-                from .exceptions import InternalServerError
-
-                validation_error = InternalServerError(
-                    f"レスポンスバリデーションエラー: {str(e)}",
-                    details={"validation_error": str(e)},
-                )
-                error_response = self._error_registry.handle_error(
-                    validation_error, request, self.context
-                )
-                error_response = self._apply_cors_headers(request, error_response, route)
-                return error_response.to_lambda_response()
-        return result
 
     def _handle_global_error(self, error: Exception) -> Dict[str, Any]:
         """グローバルエラーハンドリング"""

--- a/lambapi/router.py
+++ b/lambapi/router.py
@@ -5,7 +5,7 @@ Router クラス
 複数のルートをグループ化し、プレフィックスやタグを設定できます。
 """
 
-from typing import Callable, Optional, List, Type, Any, Union
+from typing import Callable, Optional, List, Any, Union
 
 from .core import Route
 from .base_router import BaseRouterMixin
@@ -32,14 +32,12 @@ class Router(BaseRouterMixin):
         path: str,
         method: str,
         handler: Callable,
-        request_format: Optional[Type] = None,
-        response_format: Optional[Type] = None,
         cors: Union[bool, CORSConfig, None] = None,
     ) -> Callable:
         """ルートを追加"""
         # プレフィックスを適用
         full_path = f"{self.prefix}{path}" if path != "/" else self.prefix or "/"
-        route = Route(full_path, method, handler, request_format, response_format)
+        route = Route(full_path, method, handler)
         self.routes.append(route)
         return handler
 
@@ -57,7 +55,5 @@ class Router(BaseRouterMixin):
                     full_path,
                     route.method,
                     route.handler,
-                    route.request_format,
-                    route.response_format,
                 )
                 self.routes.append(new_route)

--- a/tests/test_base_router.py
+++ b/tests/test_base_router.py
@@ -31,10 +31,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -48,9 +46,7 @@ class TestBaseRouterMixin:
         assert call_args[0] == "/test"  # path
         assert call_args[1] == "GET"  # method
         assert call_args[2] == test_handler  # handler
-        assert call_args[3] is None  # request_format
-        assert call_args[4] is None  # response_format
-        assert call_args[5] is None  # cors
+        assert call_args[3] is None  # cors
 
     def test_get_decorator_with_default_path(self):
         """GET デコレータのデフォルトパステスト"""
@@ -59,10 +55,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -93,17 +87,13 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
 
-        @router.get(
-            "/users", request_format=RequestFormat, response_format=ResponseFormat, cors=cors_config
-        )
+        @router.get("/users", cors=cors_config)
         def get_users():
             return {"users": []}
 
@@ -112,9 +102,7 @@ class TestBaseRouterMixin:
         assert call_args[0] == "/users"
         assert call_args[1] == "GET"
         assert call_args[2] == get_users
-        assert call_args[3] == RequestFormat
-        assert call_args[4] == ResponseFormat
-        assert call_args[5] == cors_config
+        assert call_args[3] == cors_config
 
     def test_post_decorator_basic(self):
         """POST デコレータの基本テスト"""
@@ -123,10 +111,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -148,10 +134,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -173,10 +157,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -198,10 +180,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -223,10 +203,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -279,9 +257,7 @@ class TestBaseRouterMixin:
         """デコレータが元の関数を返すことをテスト"""
 
         class MockRouter(BaseRouterMixin):
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
+            def _add_route(self, path, method, handler, cors=None):
                 return handler  # 元の関数を返す
 
         router = MockRouter()
@@ -300,10 +276,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -331,67 +305,38 @@ class TestBaseRouterMixin:
 
         assert len(router.calls) == 4
 
-        cors_values = [call[5] for call in router.calls]
+        cors_values = [call[3] for call in router.calls]
         assert True in cors_values
         assert False in cors_values
         assert cors_config in cors_values
         assert None in cors_values
 
     def test_request_response_format_parameters(self):
-        """リクエスト・レスポンス形式パラメータのテスト"""
-        from dataclasses import dataclass
-
-        @dataclass
-        class UserRequest:
-            name: str
-            email: str
-
-        @dataclass
-        class UserResponse:
-            id: int
-            name: str
-            email: str
+        """リクエスト・レスポンス形式パラメータのテスト - request_format/response_format が削除されたため簡素化"""
 
         class MockRouter(BaseRouterMixin):
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
 
-        # request_format のみ
-        @router.post("/request-only", request_format=UserRequest)
+        @router.post("/request-only")
         def handler1(request):
             return {}
 
-        # response_format のみ
-        @router.get("/response-only", response_format=UserResponse)
+        @router.get("/response-only")
         def handler2():
             return {}
 
-        # 両方指定
-        @router.put("/both", request_format=UserRequest, response_format=UserResponse)
+        @router.put("/both")
         def handler3(request):
             return {}
 
         assert len(router.calls) == 3
-
-        # request_format のみのケース
-        assert router.calls[0][3] == UserRequest
-        assert router.calls[0][4] is None
-
-        # response_format のみのケース
-        assert router.calls[1][3] is None
-        assert router.calls[1][4] == UserResponse
-
-        # 両方指定のケース
-        assert router.calls[2][3] == UserRequest
-        assert router.calls[2][4] == UserResponse
 
     def test_path_parameter_variations(self):
         """パスパラメータのバリエーションテスト"""
@@ -400,10 +345,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -443,10 +386,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router = MockRouter()
@@ -479,16 +420,12 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.routes = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
+            def _add_route(self, path, method, handler, cors=None):
                 # カスタム実装
                 route_info = {
                     "path": path,
                     "method": method,
                     "handler": handler,
-                    "request_format": request_format,
-                    "response_format": response_format,
                     "cors": cors,
                 }
                 self.routes.append(route_info)
@@ -513,10 +450,8 @@ class TestBaseRouterMixin:
             def __init__(self):
                 self.calls = []
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
-                self.calls.append((path, method, handler, request_format, response_format, cors))
+            def _add_route(self, path, method, handler, cors=None):
+                self.calls.append((path, method, handler, cors))
                 return handler
 
         router1 = MockRouter()
@@ -540,9 +475,7 @@ class TestBaseRouterMixin:
         """_add_route でのエラーハンドリングテスト"""
 
         class FailingRouter(BaseRouterMixin):
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
+            def _add_route(self, path, method, handler, cors=None):
                 raise RuntimeError("Route addition failed")
 
         router = FailingRouter()
@@ -555,21 +488,17 @@ class TestBaseRouterMixin:
                 return {}
 
     def test_decorator_parameter_forwarding(self):
-        """デコレータパラメータの転送テスト"""
+        """デコレータパラメータの転送テスト - request_format/response_format が削除されたため簡素化"""
 
         class ParameterCapturingRouter(BaseRouterMixin):
             def __init__(self):
                 self.captured_params = {}
 
-            def _add_route(
-                self, path, method, handler, request_format=None, response_format=None, cors=None
-            ):
+            def _add_route(self, path, method, handler, cors=None):
                 self.captured_params = {
                     "path": path,
                     "method": method,
                     "handler": handler,
-                    "request_format": request_format,
-                    "response_format": response_format,
                     "cors": cors,
                 }
                 return handler
@@ -577,9 +506,7 @@ class TestBaseRouterMixin:
         router = ParameterCapturingRouter()
         cors_config = create_cors_config(origins=["https://test.com"])
 
-        @router.post(
-            "/complex-endpoint", request_format=dict, response_format=list, cors=cors_config
-        )
+        @router.post("/complex-endpoint", cors=cors_config)
         def complex_handler(request):
             return []
 
@@ -587,6 +514,4 @@ class TestBaseRouterMixin:
         assert params["path"] == "/complex-endpoint"
         assert params["method"] == "POST"
         assert params["handler"] == complex_handler
-        assert params["request_format"] == dict
-        assert params["response_format"] == list
         assert params["cors"] == cors_config

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -306,30 +306,14 @@ class TestRouter:
         assert router.routes[1].handler == handler2
 
     def test_router_with_request_response_formats(self):
-        """リクエスト・レスポンス形式指定のテスト"""
-        from dataclasses import dataclass
-
-        @dataclass
-        class UserRequest:
-            name: str
-            age: int
-
-        @dataclass
-        class UserResponse:
-            id: int
-            name: str
-            age: int
-
+        """リクエスト・レスポンス形式指定のテスト - request_format/response_format が削除されたため簡素化"""
         router = Router()
 
-        @router.post("/users", request_format=UserRequest, response_format=UserResponse)
+        @router.post("/users")
         def create_user(request):
             return {"created": True}
 
         assert len(router.routes) == 1
-        route = router.routes[0]
-        assert route.request_format == UserRequest
-        assert route.response_format == UserResponse
 
     def test_empty_router_include(self):
         """空のルーター統合のテスト"""


### PR DESCRIPTION
- BaseRouterMixin: 全HTTPメソッドデコレータから該当パラメータを削除
- Route.__init__: request_format/response_formatパラメータを削除
- Router._add_route: 該当パラメータを削除
- テストコード: 削除されたパラメータに対応するテストを修正
- 未使用importを削除してコードを整理

BREAKING CHANGE: request_format/response_formatパラメータが削除されました