### PR TITLE
fix: examples の動作しない request_format/response_format コードを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,5 @@ temp/
 .pypirc
 
 .definition/
+
+.serena/

--- a/examples/basic_app.py
+++ b/examples/basic_app.py
@@ -64,11 +64,7 @@ def create_app(event, context):
 
     @app.post("/users")
     def create_user(request):
-        """ユーザー作成（JSON ボディ）
-
-        新機能: request_format と response_format でバリデーションが可能
-        例: @app.post("/users", request_format=CustomRequest, response_format=CustomResponse)
-        """
+        """ユーザー作成（JSON ボディ）"""
         try:
             user_data = request.json()
 


### PR DESCRIPTION
## 問題

examples/ ディレクトリのサンプルコードに、現在は実装されていない `request_format` と `response_format` パラメータが含まれており、実際には動作しないコードになっていました。

## 修正内容

### examples/basic_app.py
- 動作しない機能についてのコメント（行69-70）を削除

### examples/validation_example.py  
- 実装されていないデコレータパラメータを削除
  - `@app.post("/users", request_format=CreateUserRequest, response_format=UserResponse)`
  - `@app.get("/users/{user_id}", response_format=UserResponse)`
- 現在実装されている依存性注入機能を使用した正しいコードに修正
  - `Body(...)`、`Path(...)` を活用
  - 関数シグネチャを適切に修正
- サンプル説明とコメントを実際の機能に合わせて更新

## テスト

- 修正後のサンプルコードが実際に動作することを確認
- 依存性注入機能が正常に動作することを確認

## 影響範囲

- examples/ ディレクトリのサンプルコード
- ドキュメント・チュートリアル品質の向上
- 利用者の混乱解消

## 関連Issue

Closes #42