### PR TITLE
test: DynamoDB接続チェックによるテストスキップ対応

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -87,7 +87,21 @@ class TestBaseUser:
         assert "password" not in payload
 
 
+def _dynamodb_available():
+    """DynamoDB ローカルが利用可能かチェック"""
+    try:
+        import boto3
+
+        dynamodb = boto3.resource("dynamodb", endpoint_url="http://localhost:8000")
+        # 簡単な接続テスト
+        dynamodb.meta.client.list_tables()
+        return True
+    except Exception:
+        return False
+
+
 @pytest.mark.skipif(not BOTO3_AVAILABLE, reason="boto3 not available")
+@pytest.mark.skipif(not _dynamodb_available(), reason="DynamoDB not available")
 class TestDynamoDBAuth:
     """DynamoDBAuth クラスのテスト"""
 


### PR DESCRIPTION
## Summary
ローカル環境でDynamoDBが利用できない場合にテストが失敗する問題を修正しました。

## Changes
- `_dynamodb_available()` 関数を追加してDynamoDB接続を事前チェック
- `TestDynamoDBAuth` クラスに DynamoDB 利用可能性チェックを追加
- DynamoDBローカルが起動していない環境でテストが適切にスキップされるよう修正

## Test plan
- [x] **DynamoDBなし**: 9個のテストが適切にスキップされる
- [x] **全テスト**: 218 passed, 9 skipped (エラーなし)
- [x] **CI/CD**: DynamoDBが利用できない環境でもテストが通る

## Before/After
**Before:** 
```
ConnectionRefusedError: [Errno 61] Connection refused
```

**After:**
```
============================= 9 skipped in 25.83s =============================
SKIPPED [9] tests/test_auth.py: DynamoDB not available
======================= 218 passed, 9 skipped in 30.43s ========================
```

## 影響範囲
- `tests/test_auth.py` の修正のみ
- 既存の機能には影響なし
- DynamoDBが利用可能な環境では従来通りテストが実行される

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)