### PR TITLE
fix: Pydanticオブジェクトの辞書変換処理を改善

### DIFF
--- a/lambapi/core.py
+++ b/lambapi/core.py
@@ -484,10 +484,11 @@ class API(BaseRouterMixin):
             response = Response(result)
         else:
             # Pydantic BaseModel の場合は辞書に変換
-            if hasattr(result, "model_dump"):
-                response = Response(result.model_dump())
-            elif hasattr(result, "dict"):
-                response = Response(result.dict())
+            if hasattr(result, "model_dump") or hasattr(result, "dict"):
+                # json_encoders を考慮した変換を行う
+                from .validation import convert_to_dict
+
+                response = Response(convert_to_dict(result))
             else:
                 response = Response({"result": result})
 


### PR DESCRIPTION
- `convert_to_dict`関数を修正し、Pydantic v2およびv1の両方に対応するようにしました。
- APIクラス内でのレスポンス生成時に、Pydanticオブジェクトを適切に辞書に変換するために`convert_to_dict`を使用するように変更しました。