### PR TITLE
feat: DynamoDBAuth クラスのログアウトとパスワード更新メソッドを改善

### DIFF
--- a/lambapi/core.py
+++ b/lambapi/core.py
@@ -248,18 +248,6 @@ class API(BaseRouterMixin):
         # ルートインデックスを再構築
         self._rebuild_route_index()
 
-    def include_auth(self, auth: Any) -> None:
-        """認証機能を追加"""
-        from .auth.dynamodb_auth import DynamoDBAuth
-        from .auth.auth_router import create_auth_router
-
-        if isinstance(auth, DynamoDBAuth):
-            # 認証エンドポイントのルーターを作成して追加
-            auth_router = create_auth_router(auth)
-            self.include_router(auth_router)
-        else:
-            raise ValueError("auth は DynamoDBAuth のインスタンスである必要があります")
-
     def _add_route(
         self,
         path: str,


### PR DESCRIPTION
- logout メソッドをリクエストからユーザーオブジェクトを受け取るように変更し、トークンの抽出を削除
- update_password メソッドをリクエストからユーザーオブジェクトを受け取るように変更し、パスワード更新の処理を簡素化
- validation_password メソッドを追加し、パスワードのバリデーションを実装
- API クラスから include_auth メソッドを削除