### PR TITLE
feat: DynamoDB 認証システムのログインメソッドのコメントを修正

### DIFF
--- a/lambapi/auth/dynamodb_auth.py
+++ b/lambapi/auth/dynamodb_auth.py
@@ -252,7 +252,7 @@ class DynamoDBAuth:
 
     def login(self, id: str, password: str) -> str:
         """ユーザーログイン"""
-        # ユーザー取得（IDのみ）
+        # ユーザー取得
         existing_user = self._get_user_by_id(id)
 
         if not existing_user or not existing_user.verify_password(password):


### PR DESCRIPTION
- `login` メソッドのコメントを「ユーザー取得（IDのみ）」から「ユーザー取得」に変更しました。
- `BaseUser` クラスの `to_dict` メソッドと `to_token_payload` メソッドにおいて、DynamoDB 型の変換処理を追加しました。